### PR TITLE
FFS-2174 Bruk felles GitHub workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,28 +1,11 @@
 name: CI
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up JDK 25
-        uses: actions/setup-java@v5
-        with:
-          java-version: '25'
-          distribution: 'temurin'
-
-      - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v5
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Run tests
-        run: ./gradlew test
-
-      - name: Build project
-        run: ./gradlew build
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-library-ci.yaml@main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,32 +2,10 @@ name: Publish to Reposilite
 
 on:
   release:
-    types: [ published ]
+    types:
+      - published
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set version
-        run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF#refs/*/} | sed 's/^v//')" >> $GITHUB_ENV
-
-      - name: Set up JDK 25
-        uses: actions/setup-java@v5
-        with:
-          java-version: '25'
-          distribution: 'temurin'
-
-      - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v5
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Publish Build
-        run: ./gradlew clean publish -Pversion=${{ env.RELEASE_VERSION }}
-        env:
-          REPOSILITE_USERNAME: ${{ secrets.REPOSILITE_USERNAME }}
-          REPOSILITE_PASSWORD: ${{ secrets.REPOSILITE_PASSWORD }}
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-library-publish-reposilite.yaml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replace repository-local CI and publish workflows with reusable workflows from `FINTLabs/fint-flyt-github-workflows`.
- Keep release publishing through the shared Reposilite workflow.

## Validation
- YAML parse completed for changed workflow files.
- `git diff --check` completed.